### PR TITLE
Failsafe JS compression gets failsafe. Upgraded to YUI compressor versio...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ libraries = [
 	commons_httpclient: 'commons-httpclient:commons-httpclient:3.1',
 	xstream: 'com.thoughtworks.xstream:xstream:1.3.1',
 	dwr: 'org.directwebremoting:dwr:3.0.0.161.dev',
-	yuicompressor: 'com.yahoo.platform.yui:yuicompressor:2.4.2',
+	yuicompressor: 'com.yahoo.platform.yui:yuicompressor:2.4.7',
 	htmlparser: 'org.htmlparser:htmlparser:1.6',
 	hsqldb: 'org.hsqldb:hsqldb:1.8.0.10',
 	apache_poi: 'org.apache.poi:poi:3.5-FINAL'

--- a/common/src/org/riotfamily/common/web/performance/YUIJavaScriptCompressor.java
+++ b/common/src/org/riotfamily/common/web/performance/YUIJavaScriptCompressor.java
@@ -154,7 +154,7 @@ public class YUIJavaScriptCompressor implements Compressor {
 				try {
 					compressInternal(in, out, errorReporter);
 				}
-				catch (EvaluatorException e) {
+				catch (RuntimeException e) {
 					log.warn("JavaScript compression failed, serving uncompressed script.");
 					out.write(buffer.toString());
 				}
@@ -179,6 +179,7 @@ public class YUIJavaScriptCompressor implements Compressor {
 			ErrorReporter errorReporter) 
 			throws EvaluatorException, IOException {
 		
+		// TODO : integrate yuglify :  https://yuilibrary.com/projects/yuicompressor/ticket/2528157
 		JavaScriptCompressor compressor = new JavaScriptCompressor(in, errorReporter);
 		compressor.compress(out, linebreak, munge, warn, 
 				preserveAllSemiColons, !mergeStringLiterals);


### PR DESCRIPTION
YUI Compressor throws a plain RuntimeException when created with invalid JavaScript. Currently, only an EvaluationException is caught. Updated to most recent version 2.4.7 with source code availability in central maven repo.
